### PR TITLE
Add reapply, revert and Base.inv fallbacks

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -100,7 +100,7 @@ isrevertible(::Type{<:Transform}) = false
 # revert does not need to be defined for non-revertible transforms
 function revert(transform::Transform, newobject, cache)
   if !isrevertible(transform)
-    throw(ArgumentError("Can't revert the non-revertible transform $transform"))
+    throw(ErrorException("Can't revert the non-revertible transform $transform"))
   end
   throw("Transform $transform is revertible but revert is not yet implemented")
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -97,11 +97,31 @@ isrevertible(transform::Transform) =
   isrevertible(typeof(transform))
 isrevertible(::Type{<:Transform}) = false
 
+# revert does not need to be defined for non-revertible transforms
+function revert(transform::Transform, newobject, cache)
+  if !isrevertible(transform)
+    throw(ArgumentError("Can't revert the non-revertible transform $transform"))
+  end
+  return revert(transform, newobject, cache)
+end
+
 isinvertible(transform::Transform) =
   isinvertible(typeof(transform))
 isinvertible(::Type{<:Transform}) = false
 
+# Base.inv does not need to be defined for non-invertible transforms
+function Base.inv(transform::Transform)
+  if !isinvertible(transform)
+    throw(ArgumentError("Can't invert the non-invertible transform $transform"))
+  end
+  return inv(transform)
+end
+
 preprocess(transform::Transform, object) = nothing
+
+# reapply falls back to apply if not defined
+reapply(transform::Transform, object, cache) =
+  apply(transform, object) 
 
 (transform::Transform)(object) =
   apply(transform, object) |> first

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -112,7 +112,7 @@ isinvertible(::Type{<:Transform}) = false
 # Base.inv does not need to be defined for non-invertible transforms
 function Base.inv(transform::Transform)
   if !isinvertible(transform)
-    throw(ArgumentError("Can't invert the non-invertible transform $transform"))
+    throw(ErrorException("Can't invert the non-invertible transform $transform"))
   end
   throw(ErrorException("Transform $transform is invertible but inv is not yet implemented"))
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -114,7 +114,7 @@ function Base.inv(transform::Transform)
   if !isinvertible(transform)
     throw(ArgumentError("Can't invert the non-invertible transform $transform"))
   end
-  throw("Transform $transform is invertible but inv is not yet implemented")
+  throw(ErrorException("Transform $transform is invertible but inv is not yet implemented"))
 end
 
 preprocess(transform::Transform, object) = nothing

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -102,7 +102,7 @@ function revert(transform::Transform, newobject, cache)
   if !isrevertible(transform)
     throw(ErrorException("Can't revert the non-revertible transform $transform"))
   end
-  throw("Transform $transform is revertible but revert is not yet implemented")
+  throw(ErrorException("Transform $transform is revertible but revert is not yet implemented"))
 end
 
 isinvertible(transform::Transform) =

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -97,7 +97,6 @@ isrevertible(transform::Transform) =
   isrevertible(typeof(transform))
 isrevertible(::Type{<:Transform}) = false
 
-# revert does not need to be defined for non-revertible transforms
 function revert(transform::Transform, newobject, cache)
   if !isrevertible(transform)
     throw(ErrorException("Can't revert the non-revertible transform $transform"))
@@ -109,7 +108,6 @@ isinvertible(transform::Transform) =
   isinvertible(typeof(transform))
 isinvertible(::Type{<:Transform}) = false
 
-# Base.inv does not need to be defined for non-invertible transforms
 function Base.inv(transform::Transform)
   if !isinvertible(transform)
     throw(ErrorException("Can't invert the non-invertible transform $transform"))
@@ -121,7 +119,7 @@ preprocess(transform::Transform, object) = nothing
 
 # reapply falls back to apply if not defined
 reapply(transform::Transform, object, cache) =
-  apply(transform, object) 
+  apply(transform, object) |> first
 
 (transform::Transform)(object) =
   apply(transform, object) |> first

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -17,15 +17,6 @@ trait can be evaluated directly at any object.
 abstract type Transform end
 
 """
-    assertions(transform)
-
-Returns a list of assertion functions for the `transform`. An assertion
-function is a function that takes an object as input and checks if the
-object is valid for the `transform`.
-"""
-function assertions end
-
-"""
     isrevertible(transform)
 
 Tells whether or not the `transform` is revertible, i.e. supports a
@@ -50,6 +41,15 @@ exists a one-to-one mapping between input and output spaces.
 See also [`isrevertible`](@ref).
 """
 function isinvertible end
+
+"""
+    assertions(transform)
+
+Returns a list of assertion functions for the `transform`. An assertion
+function is a function that takes an object as input and checks if the
+object is valid for the `transform`.
+"""
+function assertions end
 
 """
     prep = preprocess(transform, object)
@@ -80,8 +80,9 @@ function revert end
 """
     newobject = reapply(transform, object, cache)
 
-Reapply the `transform` to (a possibly different) `object` using a `cache`
-that was created with a previous [`apply`](@ref) call.
+Reapply the `transform` to (a possibly different) `object`
+using a `cache` that was created with a previous [`apply`](@ref)
+call. Fallback to [`apply`](@ref) without using the `cache`.
 """
 function reapply end
 
@@ -89,35 +90,18 @@ function reapply end
 # TRANSFORM FALLBACKS
 # --------------------
 
-assertions(transform::Transform) =
-  assertions(typeof(transform))
-assertions(::Type{<:Transform}) = []
-
 isrevertible(transform::Transform) =
   isrevertible(typeof(transform))
 isrevertible(::Type{<:Transform}) = false
-
-function revert(transform::Transform, newobject, cache)
-  if !isrevertible(transform)
-    throw(ErrorException("Can't revert the non-revertible transform $transform"))
-  end
-  throw(ErrorException("Transform $transform is revertible but revert is not yet implemented"))
-end
 
 isinvertible(transform::Transform) =
   isinvertible(typeof(transform))
 isinvertible(::Type{<:Transform}) = false
 
-function Base.inv(transform::Transform)
-  if !isinvertible(transform)
-    throw(ErrorException("Can't invert the non-invertible transform $transform"))
-  end
-  throw(ErrorException("Transform $transform is invertible but inv is not yet implemented"))
-end
+assertions(transform::Transform) = []
 
 preprocess(transform::Transform, object) = nothing
 
-# reapply falls back to apply if not defined
 reapply(transform::Transform, object, cache) =
   apply(transform, object) |> first
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -102,7 +102,7 @@ function revert(transform::Transform, newobject, cache)
   if !isrevertible(transform)
     throw(ArgumentError("Can't revert the non-revertible transform $transform"))
   end
-  return revert(transform, newobject, cache)
+  throw("Transform $transform is revertible but revert is not yet implemented")
 end
 
 isinvertible(transform::Transform) =
@@ -114,7 +114,7 @@ function Base.inv(transform::Transform)
   if !isinvertible(transform)
     throw(ArgumentError("Can't invert the non-invertible transform $transform"))
   end
-  return inv(transform)
+  throw("Transform $transform is invertible but inv is not yet implemented")
 end
 
 preprocess(transform::Transform, object) = nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,10 @@ end
     @test_throws "Can't revert the non-revertible transform TestTransform()" begin
       TransformsBase.revert(T, 1, nothing)
     end
-    TransformsBase.isrevertible(::TestTransform) = true
+    @test_throws "Transform TestTransform() is revertible but revert is not yet implemented" begin
+      TransformsBase.isrevertible(::TestTransform) = true
+      TransformsBase.revert(T, 1, nothing)
+    end
     TransformsBase.revert(::TestTransform, x, cache) = x
     x2 = TransformsBase.revert(T, 1, nothing)
     @test x2 == 1
@@ -36,7 +39,10 @@ end
     @test_throws "Can't invert the non-invertible transform TestTransform()" begin
       Base.inv(T)
     end
-    TransformsBase.isinvertible(::TestTransform) = true
+    @test_throws "Transform TestTransform() is invertible but inv is not yet implemented" begin
+      TransformsBase.isinvertible(::TestTransform) = true
+      Base.inv(T)
+    end
     Base.inv(::TestTransform) = TestTransform()
     @test Base.inv(T) == T
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,37 +8,13 @@ using Test
   @test inv(Identity() → Identity()) == Identity()
   @test (Identity() → Identity()) == Identity()
 
-  # testing fallbacks
+  # test fallbacks
   struct TestTransform <: TransformsBase.Transform end
-  T = TestTransform()
-
-  # test reapply
   TransformsBase.apply(::TestTransform, x) = x, nothing
-  @test TransformsBase.reapply(T, 1, nothing) == 1
-  TransformsBase.reapply(::TestTransform, x, cache) = 2 * x
-  @test TransformsBase.reapply(T, 1, nothing) == 2
-
-  # test revert
+  T = TestTransform()
   @test !TransformsBase.isrevertible(T)
-  @test_throws ErrorException("Can't revert the non-revertible transform TestTransform()") begin
-    TransformsBase.revert(T, 1, nothing)
-  end
-  @test_throws ErrorException("Transform TestTransform() is revertible but revert is not yet implemented") begin
-    TransformsBase.isrevertible(::TestTransform) = true
-    TransformsBase.revert(T, 1, nothing)
-  end
-  TransformsBase.revert(::TestTransform, x, cache) = x
-  @test TransformsBase.revert(T, 1, nothing) == 1
-
-  # test inv
   @test !TransformsBase.isinvertible(T)
-  @test_throws ErrorException("Can't invert the non-invertible transform TestTransform()") begin
-    Base.inv(T)
-  end
-  @test_throws ErrorException("Transform TestTransform() is invertible but inv is not yet implemented") begin
-    TransformsBase.isinvertible(::TestTransform) = true
-    Base.inv(T)
-  end
-  Base.inv(::TestTransform) = TestTransform()
-  @test Base.inv(T) == T
+  @test TransformsBase.assertions(T) |> isempty
+  @test TransformsBase.preprocess(T) |> isnothing
+  @test TransformsBase.reapply(T, 1, nothing) == 1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Test
   @test (Identity() → Identity()) == Identity()
 
   # Testing Fallbacks
-  struct TestTransform <: TransformsBase.Transform end
+  struct TestTransform <: Transform end
   T = TestTransform()
 
   @testset "reapply" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,12 +14,12 @@ using Test
 
   # test reapply
   TransformsBase.apply(::TestTransform, x) = x, nothing
-  @test TransformsBase.reapply(T, 1, nothing) == TransformsBase.apply(T, 1) |> first
+  @test TransformsBase.reapply(T, 1, nothing) == 1
   TransformsBase.reapply(::TestTransform, x, cache) = 2 * x
   @test TransformsBase.reapply(T, 1, nothing) == 2
-  @test TransformsBase.reapply(T, 1, nothing) != TransformsBase.apply(T, 1) |> first
 
   # test revert
+  @test !TransformsBase.isrevertible(T)
   @test_throws ErrorException("Can't revert the non-revertible transform TestTransform()") begin
     TransformsBase.revert(T, 1, nothing)
   end
@@ -28,8 +28,7 @@ using Test
     TransformsBase.revert(T, 1, nothing)
   end
   TransformsBase.revert(::TestTransform, x, cache) = x
-  x2 = TransformsBase.revert(T, 1, nothing)
-  @test x2 == 1
+  @test TransformsBase.revert(T, 1, nothing) == 1
 
   # test inv
   @test !TransformsBase.isinvertible(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ using Test
   T = TestTransform()
 
   # test reapply
-  TransformsBase.apply(::TestTransform, x) = x
+  TransformsBase.apply(::TestTransform, x) = x, nothing
   @test TransformsBase.reapply(T, 1, nothing) == TransformsBase.apply(T, 1) |> first
   TransformsBase.reapply(::TestTransform, x, cache) = 2 * x
   @test TransformsBase.reapply(T, 1, nothing) == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,3 +8,36 @@ using Test
   @test inv(Identity() → Identity()) == Identity()
   @test (Identity() → Identity()) == Identity()
 end
+
+@testset "Testing Fallbacks" begin
+  struct TestTransform <: TransformsBase.Transform end
+  T = TestTransform()
+
+  @testset "reapply" begin
+    TransformsBase.apply(::TestTransform, x) = x, nothing
+    @test TransformsBase.reapply(T, 1, nothing) == TransformsBase.apply(T, 1) |> first
+    TransformsBase.reapply(::TestTransform, x, cache) = 2 * x
+    @test TransformsBase.reapply(T, 1, nothing) == 2
+    @test TransformsBase.reapply(T, 1, nothing) != TransformsBase.apply(T, 1) |> first
+  end
+
+  @testset "revert" begin
+    @test_throws "Can't revert the non-revertible transform TestTransform()" begin
+      TransformsBase.revert(T, 1, nothing)
+    end
+    TransformsBase.isrevertible(::TestTransform) = true
+    TransformsBase.revert(::TestTransform, x, cache) = x
+    x2 = TransformsBase.revert(T, 1, nothing)
+    @test x2 == 1
+  end
+
+  @testset "isinvertible" begin
+    @test !TransformsBase.isinvertible(T)
+    @test_throws "Can't invert the non-invertible transform TestTransform()" begin
+      Base.inv(T)
+    end
+    TransformsBase.isinvertible(::TestTransform) = true
+    Base.inv(::TestTransform) = TestTransform()
+    @test Base.inv(T) == T
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,6 @@ using Test
   @test !TransformsBase.isrevertible(T)
   @test !TransformsBase.isinvertible(T)
   @test TransformsBase.assertions(T) |> isempty
-  @test TransformsBase.preprocess(T) |> isnothing
+  @test TransformsBase.preprocess(T, nothing) |> isnothing
   @test TransformsBase.reapply(T, 1, nothing) == 1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ end
   T = TestTransform()
 
   @testset "reapply" begin
-    TransformsBase.apply(::TestTransform, x) = x, nothing
+    TransformsBase.apply(::TestTransform, x) = x
     @test TransformsBase.reapply(T, 1, nothing) == TransformsBase.apply(T, 1) |> first
     TransformsBase.reapply(::TestTransform, x, cache) = 2 * x
     @test TransformsBase.reapply(T, 1, nothing) == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,9 +7,8 @@ using Test
   @test inv(Identity()) == Identity()
   @test inv(Identity() → Identity()) == Identity()
   @test (Identity() → Identity()) == Identity()
-end
 
-@testset "Testing Fallbacks" begin
+  # Testing Fallbacks
   struct TestTransform <: TransformsBase.Transform end
   T = TestTransform()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,41 +8,38 @@ using Test
   @test inv(Identity() → Identity()) == Identity()
   @test (Identity() → Identity()) == Identity()
 
-  # Testing Fallbacks
-  struct TestTransform <: Transform end
+  ## Testing Fallbacks
+  struct TestTransform <: TransformsBase.Transform end
   T = TestTransform()
 
-  @testset "reapply" begin
-    TransformsBase.apply(::TestTransform, x) = x
-    @test TransformsBase.reapply(T, 1, nothing) == TransformsBase.apply(T, 1) |> first
-    TransformsBase.reapply(::TestTransform, x, cache) = 2 * x
-    @test TransformsBase.reapply(T, 1, nothing) == 2
-    @test TransformsBase.reapply(T, 1, nothing) != TransformsBase.apply(T, 1) |> first
-  end
+  # test reapply
+  TransformsBase.apply(::TestTransform, x) = x
+  @test TransformsBase.reapply(T, 1, nothing) == TransformsBase.apply(T, 1) |> first
+  TransformsBase.reapply(::TestTransform, x, cache) = 2 * x
+  @test TransformsBase.reapply(T, 1, nothing) == 2
+  @test TransformsBase.reapply(T, 1, nothing) != TransformsBase.apply(T, 1) |> first
 
-  @testset "revert" begin
-    @test_throws "Can't revert the non-revertible transform TestTransform()" begin
-      TransformsBase.revert(T, 1, nothing)
-    end
-    @test_throws "Transform TestTransform() is revertible but revert is not yet implemented" begin
-      TransformsBase.isrevertible(::TestTransform) = true
-      TransformsBase.revert(T, 1, nothing)
-    end
-    TransformsBase.revert(::TestTransform, x, cache) = x
-    x2 = TransformsBase.revert(T, 1, nothing)
-    @test x2 == 1
+  # test revert
+  @test_throws "Can't revert the non-revertible transform TestTransform()" begin
+    TransformsBase.revert(T, 1, nothing)
   end
+  @test_throws "Transform TestTransform() is revertible but revert is not yet implemented" begin
+    TransformsBase.isrevertible(::TestTransform) = true
+    TransformsBase.revert(T, 1, nothing)
+  end
+  TransformsBase.revert(::TestTransform, x, cache) = x
+  x2 = TransformsBase.revert(T, 1, nothing)
+  @test x2 == 1
 
-  @testset "isinvertible" begin
-    @test !TransformsBase.isinvertible(T)
-    @test_throws "Can't invert the non-invertible transform TestTransform()" begin
-      Base.inv(T)
-    end
-    @test_throws "Transform TestTransform() is invertible but inv is not yet implemented" begin
-      TransformsBase.isinvertible(::TestTransform) = true
-      Base.inv(T)
-    end
-    Base.inv(::TestTransform) = TestTransform()
-    @test Base.inv(T) == T
+  # test inv
+  @test !TransformsBase.isinvertible(T)
+  @test_throws "Can't invert the non-invertible transform TestTransform()" begin
+    Base.inv(T)
   end
+  @test_throws "Transform TestTransform() is invertible but inv is not yet implemented" begin
+    TransformsBase.isinvertible(::TestTransform) = true
+    Base.inv(T)
+  end
+  Base.inv(::TestTransform) = TestTransform()
+  @test Base.inv(T) == T
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using Test
   @test inv(Identity() → Identity()) == Identity()
   @test (Identity() → Identity()) == Identity()
 
-  ## Testing Fallbacks
+  # testing fallbacks
   struct TestTransform <: TransformsBase.Transform end
   T = TestTransform()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,10 +20,10 @@ using Test
   @test TransformsBase.reapply(T, 1, nothing) != TransformsBase.apply(T, 1) |> first
 
   # test revert
-  @test_throws "Can't revert the non-revertible transform TestTransform()" begin
+  @test_throws ErrorException("Can't revert the non-revertible transform TestTransform()") begin
     TransformsBase.revert(T, 1, nothing)
   end
-  @test_throws "Transform TestTransform() is revertible but revert is not yet implemented" begin
+  @test_throws ErrorException("Transform TestTransform() is revertible but revert is not yet implemented") begin
     TransformsBase.isrevertible(::TestTransform) = true
     TransformsBase.revert(T, 1, nothing)
   end
@@ -33,10 +33,10 @@ using Test
 
   # test inv
   @test !TransformsBase.isinvertible(T)
-  @test_throws "Can't invert the non-invertible transform TestTransform()" begin
+  @test_throws ErrorException("Can't invert the non-invertible transform TestTransform()") begin
     Base.inv(T)
   end
-  @test_throws "Transform TestTransform() is invertible but inv is not yet implemented" begin
+  @test_throws ErrorException("Transform TestTransform() is invertible but inv is not yet implemented") begin
     TransformsBase.isinvertible(::TestTransform) = true
     Base.inv(T)
   end


### PR DESCRIPTION
Have added some fallbacks that make it easier for those implementing the interface. In particular,

- If `reapply` is not implemented then it falls back to `apply` while ignoring cache
- If `isrevertible` is `false` then calling `revertible` throws an error signaling that the transform is not revertible
- Likewise for `isinvertible`

By this, `reapply` becomes officially optional and `revert`/`Base.inv` will throw friendlier error when `isrevertible` or `isinvertible` are false respectively.